### PR TITLE
Correction in weight initialization of output layers

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -121,7 +121,7 @@ class ParallelMLP(MegatronModule):
             in_features=config.ffn_hidden_size,
             out_features=config.hidden_size,
             skip_bias_add=True,
-            init_method=config.init_method,
+            init_method=config.output_layer_init_method,
             transpose=True
         )
 


### PR DESCRIPTION
- After this change, we get identical loss curves with Megatron-LM.
![image](https://github.com/axonn-ai/Megatron-LM/assets/16764680/88f7b883-fe0c-41ea-abeb-e7f2c97569a4)
