### PR TITLE
Remove requirement to initialize MPI for tensor+data parallelism

### DIFF
--- a/examples/get_rank_from_slurm.sh
+++ b/examples/get_rank_from_slurm.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# select_gpu_device wrapper script
+export RANK=${SLURM_PROCID}
+exec $*

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1004,6 +1004,7 @@ def _add_distributed_args(parser):
                        help='Overlap reduce scatters in backward pass of AxoNN\'s tensor parallelism')
     group.add_argument('--num-layers-for-caching-weights-in-depth-tensor-parallel-all-gather', type=int, default=0,
                        help='number of layers to cache weights during the first all-gather for a batch')
+    group.add_argument('--layer-caching-level', type=int, default=2)
     group.add_argument('--overlap-axonn-all-gather', action='store_true', default=False,
                        help='Overlap all-gathers in forward pass of AxoNN\'s tensor parallelism')
     

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -159,7 +159,7 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
     return train_ds, valid_ds, test_ds
 
 
-def set_device_and_init_torch_dist():
+def set_device_and_init_torch_dist_mpi():
     from mpi4py import MPI
     import os
 
@@ -185,6 +185,11 @@ def set_device_and_init_torch_dist():
 
     os.environ["RANK"] = str(world_rank)
     os.environ["WORLD_SIZE"] = str(world_size)
+
+def set_device_and_init_torch_dist():
+    torch.distributed.init_process_group(
+            backend="nccl",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. MPI.Init() can cause unnecessary delays or even hangs at scale. This PR makes it such that MPI.Init() is optional. 
2. Adding an option to only cache the weights of the first MLP layer, which has least overlap with the preceeding layer,